### PR TITLE
RET-4397: Tests for old cases with no data for sorting fields

### DIFF
--- a/src/functionalTest/resources/scenarios/employment/ET-RET-2379-ReviewReferralResponseAdmin-IsUrgent-shouldCreateTask.json
+++ b/src/functionalTest/resources/scenarios/employment/ET-RET-2379-ReviewReferralResponseAdmin-IsUrgent-shouldCreateTask.json
@@ -24,7 +24,7 @@
                     {
                       "value": {
                         "isUrgentReply": "No",
-                        "replyDateTime": "2023-10-01T12:00:00.000"
+                        "replyDateTime": null
                       }
                     },
                     {
@@ -42,7 +42,7 @@
                     {
                       "value": {
                         "isUrgentReply": "No",
-                        "replyDateTime": "2023-10-01T13:00:00.000"
+                        "replyDateTime": null
                       }
                     }
                   ]
@@ -78,10 +78,10 @@
                           "referralReplyCollection": [
                             {
                               "value": {
-                                "referralSubject": "ET1",
+                                "referralSubject": null,
                                 "directionTo": "Legal officer",
                                 "isUrgentReply": "No",
-                                "replyDateTime": "2023-10-01T12:00:00.000"
+                                "replyDateTime": null
                               }
                             },
                             {
@@ -102,10 +102,10 @@
                           "referralReplyCollection": [
                             {
                               "value": {
-                                "referralSubject": "ET3/ECC",
+                                "referralSubject": null,
                                 "directionTo": "Admin",
                                 "isUrgentReply": "No",
-                                "replyDateTime": "2023-10-01T13:00:00.000"
+                                "replyDateTime": null
                               }
                             }
                           ]

--- a/src/functionalTest/resources/scenarios/employment/ET-RET-2383-ReviewReferralResponseLegalOps-NotUrgent-shouldCreateTask.json
+++ b/src/functionalTest/resources/scenarios/employment/ET-RET-2383-ReviewReferralResponseLegalOps-NotUrgent-shouldCreateTask.json
@@ -47,10 +47,10 @@
                           "referralReplyCollection": [
                             {
                               "value": {
-                                "referralSubject": "Amend claim",
+                                "referralSubject": null,
                                 "directionTo": "Admin",
                                 "isUrgentReply": "Yes",
-                                "replyDateTime": "2023-10-01T12:00:00.000"
+                                "replyDateTime": null
                               }
                             },
                             {
@@ -71,10 +71,10 @@
                           "referralReplyCollection": [
                             {
                               "value": {
-                                "referralSubject": "ET3/ECC",
+                                "referralSubject": null,
                                 "directionTo": "Legal officer",
                                 "isUrgentReply": "Yes",
-                                "replyDateTime": "2023-10-01T13:00:00.000"
+                                "replyDateTime": null
                               }
                             }
                           ]

--- a/src/functionalTest/resources/scenarios/employment/ET-RET-2386-ReviewReferralResponseJudiciary-IsUrgent-shouldCreateTask.json
+++ b/src/functionalTest/resources/scenarios/employment/ET-RET-2386-ReviewReferralResponseJudiciary-IsUrgent-shouldCreateTask.json
@@ -78,10 +78,10 @@
                           "referralReplyCollection": [
                             {
                               "value": {
-                                "referralSubject": "Amend claim",
+                                "referralSubject": null,
                                 "directionTo": "Admin",
                                 "isUrgentReply": "No",
-                                "replyDateTime": "2023-10-01T12:00:00.000"
+                                "replyDateTime": null
                               }
                             },
                             {
@@ -102,10 +102,10 @@
                           "referralReplyCollection": [
                             {
                               "value": {
-                                "referralSubject": "ET3/ECC",
+                                "referralSubject": null,
                                 "directionTo": "Judge",
                                 "isUrgentReply": "No",
-                                "replyDateTime": "2023-10-01T13:00:00.000"
+                                "replyDateTime": null
                               }
                             }
                           ]

--- a/src/functionalTest/resources/scenarios/employment/ET-RET-2501b-AmendPartyDetails-shouldCreateTask.json
+++ b/src/functionalTest/resources/scenarios/employment/ET-RET-2501b-AmendPartyDetails-shouldCreateTask.json
@@ -44,9 +44,7 @@
                           "respondCollection": [
                             {
                               "value": {
-                                "from": "Respondent",
-                                "applicationType": "Change personal details",
-                                "dateTime": "2023-10-01T12:00:00.000"
+                                "from": "Respondent"
                               }
                             },
                             {

--- a/src/functionalTest/resources/scenarios/employment/ET-RET-2501d-AmendPartyDetails-shouldCreateTask.json
+++ b/src/functionalTest/resources/scenarios/employment/ET-RET-2501d-AmendPartyDetails-shouldCreateTask.json
@@ -45,8 +45,8 @@
                             {
                               "value": {
                                 "from": "Claimant",
-                                "applicationType": "Change my personal details",
-                                "dateTime": "2023-10-01T12:00:00.000"
+                                "applicationType": null,
+                                "dateTime": null
                               }
                             },
                             {
@@ -67,8 +67,8 @@
                             {
                               "value": {
                                 "from": "Respondent",
-                                "applicationType": "Claimant not complied",
-                                "dateTime": "2023-10-01T13:00:00.000"
+                                "applicationType": null,
+                                "dateTime": null
                               }
                             }
                           ]

--- a/src/functionalTest/resources/scenarios/employment/ET-RET-3188d-ContactTribunalWithAnApplication-shouldCreateTask.json
+++ b/src/functionalTest/resources/scenarios/employment/ET-RET-3188d-ContactTribunalWithAnApplication-shouldCreateTask.json
@@ -45,8 +45,8 @@
                             {
                               "value": {
                                 "from": "Claimant",
-                                "applicationType": "Claimant not complied",
-                                "dateTime": "2023-10-01T12:00:00.000"
+                                "applicationType": null,
+                                "dateTime": null
                               }
                             },
                             {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-4397

### Change description ###
Old cases may have ReferralReplies/ApplicationReplies without data in the new datetime fields used for sorting Replies.
Update configs to replace the null with an old date for sorting purposes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```