### PR TITLE
RET-4752: IssueJudgement Task is only triggered by Judgement

### DIFF
--- a/src/functionalTest/resources/scenarios/employment/ET-RET-2450b-IssueJudgment-shouldCreateTask.json
+++ b/src/functionalTest/resources/scenarios/employment/ET-RET-2450b-IssueJudgment-shouldCreateTask.json
@@ -32,7 +32,14 @@
               "destination": "RestEndpoint",
               "template": "ccd-event-message.json",
               "replacements": {
-                "EventId": "draftAndSignJudgement"
+                "EventId": "draftAndSignJudgement",
+                "AdditionalData": {
+                  "Data": {
+                    "draftAndSignJudgement": {
+                      "isJudgement": true
+                    }
+                  }
+                }
               }
             }
           ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-4752

### Change description ###
IssueJudgement Task is only triggered when Draft And Sign Judgement IS a Judgement

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
