### PR TITLE
RET-4795: Vacated is a valid entry for Hearings

### DIFF
--- a/src/functionalTest/resources/scenarios/employment/ET-RET-2444b-DraftAndSignJudgment-shouldCreateTask.json
+++ b/src/functionalTest/resources/scenarios/employment/ET-RET-2444b-DraftAndSignJudgment-shouldCreateTask.json
@@ -44,7 +44,7 @@
                       },
                       {
                         "value": {
-                          "hearingDetailsStatus": "Heard"
+                          "hearingDetailsStatus": "Vacated"
                         }
                       }
                     ]

--- a/src/functionalTest/resources/templates/employment/message/ccd-event-message.json
+++ b/src/functionalTest/resources/templates/employment/message/ccd-event-message.json
@@ -3,6 +3,6 @@
   "CaseId": "{$GENERATED_CASE_ID}",
   "EventTimeStamp": "{$LOCAL_DATETIME_TODAY}",
   "JurisdictionId": "EMPLOYMENT",
-  "CaseTypeId": "ET_EnglandWales",
+  "CaseTypeId": "ET_Scotland",
   "UserId": "{$USER_ID}"
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-4795

### Change description ###
"Vacated" hearing dates still trigger Draft & Sign Judgement so long as one date is Heard

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
