### PR TITLE
RET-4926: ET3 Processing should only trigger once

### DIFF
--- a/src/functionalTest/resources/scenarios/employment/ET-RET-4517-Et3Processing-shouldCreateTask.json
+++ b/src/functionalTest/resources/scenarios/employment/ET-RET-4517-Et3Processing-shouldCreateTask.json
@@ -40,7 +40,7 @@
                       {
                         "value": {
                           "responseReceived": true,
-                          "responseReceivedCount": 1
+                          "responseReceivedCount": "1"
                         }
                       }
                     ]

--- a/src/functionalTest/resources/scenarios/employment/ET-RET-4517-Et3Processing-shouldCreateTask.json
+++ b/src/functionalTest/resources/scenarios/employment/ET-RET-4517-Et3Processing-shouldCreateTask.json
@@ -39,7 +39,8 @@
                     "respondentCollection": [
                       {
                         "value": {
-                          "responseReceived": true
+                          "responseReceived": true,
+                          "responseReceivedCount": 1
                         }
                       }
                     ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-4926

### Change description ###
ET3 Processing should only trigger once if multiple amendRespondentDetails have been executed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```